### PR TITLE
feat: 評価データの圧縮方法を変更

### DIFF
--- a/deft-reversi-web/index.html
+++ b/deft-reversi-web/index.html
@@ -8,6 +8,7 @@
         <meta name="twitter:title" content="Deft Reversi"/>
         <link rel="stylesheet" href="style.css">
         <link rel="icon" href="favicon.ico">
+        <script src="https://cdn.jsdelivr.net/npm/pako@1.0.11/dist/pako.min.js"></script>
     </head>
     <body>
         <div id="setup_modal" class="setup">

--- a/deft-reversi-web/main.js
+++ b/deft-reversi-web/main.js
@@ -1,6 +1,8 @@
 import __wbg_init, { add, App } from "./pkg/deft_web.js";
 
-async function decompressGzip(compressedData) {
+
+// 将来的にはこちらを使うが、現在は、多くのブラウザをサポートするため、pakoを使用する。
+async function decompressGzip_new(compressedData) {
     const ds = new DecompressionStream('gzip');
     const decompressedStream = compressedData.stream().pipeThrough(ds);
 
@@ -132,8 +134,14 @@ async function initializeOthello() {
             if (!response.ok) {
                 throw new Error('ファイルの読み込みに失敗しました');
             }
-            const data = await response.blob();
-            const decompressedData = await decompressGzip(data);
+
+
+            const data = await response.arrayBuffer();
+            const decompressedData = await pako.ungzip(data, { to: 'string' });
+
+            // 将来的にこちらを使う
+            // const data = await response.blob();
+            // const decompressedData = await decompressGzip(data);
     
             console.log("set evaluator");
             app.set_evaluator(decompressedData);


### PR DESCRIPTION
To support old browser, Change the method of decompressing evaluation data from the Compression Streams API to using the pako library